### PR TITLE
Accept page reference sequence from file input

### DIFF
--- a/utils/cli.py
+++ b/utils/cli.py
@@ -5,16 +5,29 @@ from algorithms.lru import LRUReplacement
 from algorithms.optimal import OptimalReplacement
 
 def get_page_references() -> List[int]:
+    """
+    Prompts the user to provide a file containing the page reference sequence.
+    Parses the file to extract a list of page references.
+
+    Returns:
+        List[int]: A list of page reference integers.
+    """
     while True:
+        file_path = input("Enter the path to the page reference file: ").strip()
         try:
-            input_str = input("Enter page reference sequence (space-separated integers): ")
-            page_references = list(map(int, input_str.strip().split()))
-            if not page_references:
-                print("Page reference sequence cannot be empty.")
-                continue
-            return page_references
+            with open(file_path, 'r') as file:
+                content = file.read()
+                page_references = list(map(int, content.strip().split()))
+                if not page_references:
+                    print("Page reference file is empty.")
+                    continue
+                return page_references
+        except FileNotFoundError:
+            print(f"File not found: {file_path}. Please provide a valid file path.")
         except ValueError:
-            print("Invalid input. Please enter space-separated integers.")
+            print("Invalid file format. Ensure the file contains space-separated integers.")
+        except Exception as e:
+            print(f"An error occurred while reading the file: {e}")
 
 def get_num_frames() -> int:
     while True:


### PR DESCRIPTION
This pull request modifies the CLI to accept the page reference sequence from a user-provided file instead of direct input. The changes enhance flexibility by allowing users to manage page references externally and provide them in bulk.

### Changes:
- **`utils/cli.py`**:
  - Updated `get_page_references()` to prompt for a file path containing the page reference sequence.
  - Implemented robust error handling for the following scenarios:
    - File not found.
    - Invalid file format (non-integer or empty content).
    - General I/O exceptions.
  - Ensured the page references are extracted as a list of integers.

### How to Run:
1. Prepare a text file containing a space-separated list of integers representing the page reference sequence.
2. Run the application and provide the file path when prompted.
3. Ensure:
   - The file is correctly parsed.
   - Errors are gracefully handled for invalid or missing files.
   - Valid inputs proceed to algorithm execution.

### Additional Notes:
- This feature improves usability and aligns with potential large-scale testing scenarios where direct input is impractical.