### PR TITLE
Fix memory visualization AttributeError in runner script

### DIFF
--- a/utils/runner.py
+++ b/utils/runner.py
@@ -12,7 +12,11 @@ def run_algorithms(selected_algorithms: List[Tuple[str, object]], num_frames: in
         
         for page_number in page_references:
             replacement.access_page(page_number)
-            display_memory_state(replacement.frames)
+            if isinstance(replacement.frames, dict):
+                frames = list(replacement.frames.values())
+            else:
+                frames = list(replacement.frames)
+            display_memory_state(frames)
         
         stats = replacement.get_statistics()
         stats_aggregator.add_statistics(algorithm_name, stats)


### PR DESCRIPTION
This pull request resolves an `AttributeError` occurring in `display_memory_state` during the simulation of page replacement algorithms. 

### Changes:
- Updated `runner.py` to standardize the input to `display_memory_state`:
  - Extracted `Page` objects from frames, handling both `dict` and `deque` structures used by different algorithms.
  - Ensured compatibility with all algorithms by converting frames into a consistent list of `Page` objects.

### Impact:
- Fixes runtime errors in the `LRU` and `LFU` algorithms.
- Ensures the correct visualization of memory state during the simulation.

### Related Files:
- **utils/runner.py**: Adjusted frame extraction logic.