### PR TITLE
Fix frame order, numbering, and memory visualization consistency

### DIFF
--- a/algorithms/lfu.py
+++ b/algorithms/lfu.py
@@ -4,38 +4,41 @@ from collections import defaultdict
 class LFUReplacement:
     def __init__(self, num_frames):
         self.num_frames = num_frames
-        self.frames = {}
+        self.frames = [None] * self.num_frames
         self.frequency = defaultdict(int)
-        self.min_frequency = 0
+        self.page_map = {}
         self.page_hits = 0
         self.page_faults = 0
         self.replacement_log = []
 
     def access_page(self, page_number):
-        if page_number in self.frames:
+        if page_number in self.page_map:
             self.page_hits += 1
             self.frequency[page_number] += 1
         else:
             self.page_faults += 1
-            if len(self.frames) < self.num_frames:
-                new_page = Page(page_number=page_number)
-                self.frames[page_number] = new_page
+            new_page = Page(page_number=page_number)
+            if None in self.frames:
+                frame_index = self.frames.index(None)
+                self.frames[frame_index] = new_page
+                self.page_map[page_number] = new_page
                 self.frequency[page_number] = 1
-                self.replacement_log.append(f"Loaded page {page_number} into physical memory.")
-                self.min_frequency = 1
+                self.replacement_log.append(f"Loaded page {page_number} into Frame {frame_index + 1}.")
             else:
                 # Find the page with the lowest frequency
                 min_freq = min(self.frequency.values())
-                candidates = [p for p in self.frames if self.frequency[p] == min_freq]
+                candidates = [p for p in self.page_map if self.frequency[p] == min_freq]
                 # Replace the oldest page among candidates
-                page_to_replace = candidates[0]
-                del self.frames[page_to_replace]
+                for frame_index, page in enumerate(self.frames):
+                    if page.page_number in candidates:
+                        page_to_replace = page.page_number
+                        break
+                del self.page_map[page_to_replace]
                 del self.frequency[page_to_replace]
-                self.replacement_log.append(f"Replaced page {page_to_replace} with page {page_number}.")
-                new_page = Page(page_number=page_number)
-                self.frames[page_number] = new_page
+                self.replacement_log.append(f"Replaced page {page_to_replace} with page {page_number} in Frame {frame_index + 1}.")
+                self.frames[frame_index] = new_page
+                self.page_map[page_number] = new_page
                 self.frequency[page_number] = 1
-                self.min_frequency = 1
 
     def get_statistics(self):
         total_accesses = self.page_hits + self.page_faults

--- a/algorithms/lru.py
+++ b/algorithms/lru.py
@@ -4,25 +4,36 @@ from models.page import Page
 class LRUReplacement:
     def __init__(self, num_frames):
         self.num_frames = num_frames
-        self.frames = OrderedDict()
+        self.frames = [None] * self.num_frames
+        self.page_map = {}
+        self.access_order = OrderedDict()
         self.page_hits = 0
         self.page_faults = 0
         self.replacement_log = []
 
     def access_page(self, page_number):
-        if page_number in self.frames:
+        if page_number in self.page_map:
             self.page_hits += 1
-            self.frames.move_to_end(page_number)
+            self.access_order.move_to_end(page_number)
         else:
             self.page_faults += 1
             new_page = Page(page_number=page_number)
-            if len(self.frames) < self.num_frames:
-                self.frames[page_number] = new_page
-                self.replacement_log.append(f"Loaded page {page_number} into physical memory.")
+            if None in self.frames:
+                frame_index = self.frames.index(None)
+                self.frames[frame_index] = new_page
+                self.page_map[page_number] = new_page
+                self.access_order[page_number] = None
+                self.replacement_log.append(f"Loaded page {page_number} into Frame {frame_index + 1}.")
             else:
-                oldest_page_number, _ = self.frames.popitem(last=False)
-                self.replacement_log.append(f"Replaced page {oldest_page_number} with page {page_number}.")
-                self.frames[page_number] = new_page
+                # Replace the least recently used page
+                lru_page = next(iter(self.access_order))
+                frame_index = self.frames.index(self.page_map[lru_page])
+                del self.page_map[lru_page]
+                del self.access_order[lru_page]
+                self.replacement_log.append(f"Replaced page {lru_page} with page {page_number} in Frame {frame_index + 1}.")
+                self.frames[frame_index] = new_page
+                self.page_map[page_number] = new_page
+                self.access_order[page_number] = None
 
     def get_statistics(self):
         total_accesses = self.page_hits + self.page_faults

--- a/algorithms/optimal.py
+++ b/algorithms/optimal.py
@@ -4,21 +4,24 @@ class OptimalReplacement:
     def __init__(self, num_frames, page_references):
         self.num_frames = num_frames
         self.page_references = page_references
-        self.frames = []
+        self.frames = [None] * self.num_frames
+        self.page_map = {}
         self.page_hits = 0
         self.page_faults = 0
         self.replacement_log = []
         self.current_index = 0
 
     def access_page(self, page_number):
-        if page_number in [page.page_number for page in self.frames]:
+        if page_number in self.page_map:
             self.page_hits += 1
         else:
             self.page_faults += 1
-            if len(self.frames) < self.num_frames:
-                new_page = Page(page_number=page_number)
-                self.frames.append(new_page)
-                self.replacement_log.append(f"Loaded page {page_number} into physical memory.")
+            new_page = Page(page_number=page_number)
+            if None in self.frames:
+                frame_index = self.frames.index(None)
+                self.frames[frame_index] = new_page
+                self.page_map[page_number] = new_page
+                self.replacement_log.append(f"Loaded page {page_number} into Frame {frame_index + 1}.")
             else:
                 # Determine the page to replace
                 future_indices = {}
@@ -30,10 +33,11 @@ class OptimalReplacement:
                         future_indices[page.page_number] = float('inf')
                 # Select the page with the farthest next use
                 page_to_replace = max(future_indices, key=future_indices.get)
-                self.frames = [page for page in self.frames if page.page_number != page_to_replace]
-                self.replacement_log.append(f"Replaced page {page_to_replace} with page {page_number}.")
-                new_page = Page(page_number=page_number)
-                self.frames.append(new_page)
+                frame_index = self.frames.index(self.page_map[page_to_replace])
+                del self.page_map[page_to_replace]
+                self.replacement_log.append(f"Replaced page {page_to_replace} with page {page_number} in Frame {frame_index + 1}.")
+                self.frames[frame_index] = new_page
+                self.page_map[page_number] = new_page
         self.current_index += 1
 
     def get_statistics(self):

--- a/utils/memory_visualization.py
+++ b/utils/memory_visualization.py
@@ -9,13 +9,10 @@ def display_memory_state(frames: List[Page]):
     Args:
         frames (List[Page]): A list of Page objects currently in physical memory.
     """
-    if not frames:
-        print("Physical Memory is currently empty.\n")
-        return
-    
     table = [["Frame", "Page Number"]]
     for idx, page in enumerate(frames, start=1):
-        table.append([f"Frame {idx}", page.page_number])
+        page_number = page.page_number if page else " "
+        table.append([f"Frame {idx}", page_number])
     
     print("\nCurrent Physical Memory State:")
     print(tabulate(table, headers="firstrow", tablefmt="grid"))

--- a/utils/memory_visualization.py
+++ b/utils/memory_visualization.py
@@ -11,8 +11,8 @@ def display_memory_state(frames: List[Page]):
     """
     table = [["Frame", "Page Number"]]
     for idx, page in enumerate(frames, start=1):
-        page_number = page.page_number if page else " "
+        page_number = page.page_number if page else ""
         table.append([f"Frame {idx}", page_number])
     
     print("\nCurrent Physical Memory State:")
-    print(tabulate(table, headers="firstrow", tablefmt="grid"))
+    print(tabulate(table, headers="firstrow", tablefmt="grid", colalign=("left", "right")))


### PR DESCRIPTION
This pull request addresses several issues with frame ordering, numbering consistency, and memory visualization alignment across page replacement algorithms and the memory display utility.

#### Changes Made:

- **Frame Ordering and Numbering Fixes**
  - Updated all page replacement algorithms (FIFO, LFU, LRU, Optimal) to use a fixed frame list.
  - Ensured frame numbers remain consistent during page replacements.
  - Adjusted replacement logic to correctly align with algorithm principles:
    - **FIFO:** Replaces the oldest page.
    - **LFU:** Replaces the least frequently used page.
    - **LRU:** Replaces the least recently used page.
    - **Optimal:** Replaces the page with the farthest next reference.
  - Enhanced replacement log entries to specify frame numbers clearly.

- **Memory Visualization Improvements**
  - Modified the memory visualization utility to:
    - Display empty frames as blank cells.
    - Consistently align page numbers to the right, regardless of empty frames.
    - Enhanced clarity of physical memory state visualization.

#### Files Modified:

- `algorithms/fifo.py`
- `algorithms/lfu.py`
- `algorithms/lru.py`
- `algorithms/optimal.py`
- `utils/memory_visualization.py`

#### Rationale:

These changes ensure that the page replacement algorithms adhere to their expected behaviors and that memory state visualization is intuitive, consistent, and user-friendly.